### PR TITLE
Return 404 when unknown virtual league

### DIFF
--- a/pages/virtual-leagues/[type].tsx
+++ b/pages/virtual-leagues/[type].tsx
@@ -1,11 +1,11 @@
 import { NextPage, NextPageContext } from "next";
 import VirtualLeaguePageContent from "../../components/virtual-leagues/VirtualLeaguePageContent";
-import { getVerifiedEntries, GetVerifiedEntriesResponse, } from "../../services/verified";
+import { getVerifiedEntries, VerifiedEntry, } from "../../services/verified";
 import { toVerifiedType, VerifiedType } from "../../services/VerifiedType";
 import { getVerifiedExtraInformation } from "../../utils/verifiedTypeHelper";
 
 interface LegalVerifiedType  {
-  res: GetVerifiedEntriesResponse;
+  data: VerifiedEntry[],
   verifiedType: VerifiedType
   type: "LEGALVERIFIEDTYPE"
 };
@@ -15,10 +15,14 @@ interface IllegalVerifiedType {
   type: "ILLEGALVERIFIEDTYPE"
 };
 
-type VirtualLeaguePageProps = LegalVerifiedType | IllegalVerifiedType;
+interface APIError {
+  type: "APIERROR"
+};
+
+type VirtualLeaguePageProps = LegalVerifiedType | IllegalVerifiedType | APIError;
 
 const VirtualLeaguePage: NextPage<VirtualLeaguePageProps> = props => {
-  if (props.type === "LEGALVERIFIEDTYPE" && props.res.type == "SUCCESS") {
+  if (props.type === "LEGALVERIFIEDTYPE") {
 
     const verifiedTypeInfo = getVerifiedExtraInformation(props.verifiedType);
 
@@ -26,7 +30,7 @@ const VirtualLeaguePage: NextPage<VirtualLeaguePageProps> = props => {
       <VirtualLeaguePageContent
         title={verifiedTypeInfo.title}
         description={verifiedTypeInfo.description}
-        verifiedEntries={props.res.data}
+        verifiedEntries={props.data}
         relUrl={props.verifiedType}
       />
     );
@@ -64,11 +68,17 @@ VirtualLeaguePage.getInitialProps = async (ctx: NextPageContext) => {
   }
 
   var res = await getVerifiedEntries(verifiedType);
+  if(res.type == "SUCCESS"){
+    return {
+      data: res.data,
+      verifiedType: verifiedType,
+      type: "LEGALVERIFIEDTYPE"
+    }
+  }
   return {
-    res: res,
-    verifiedType: verifiedType,
-    type: "LEGALVERIFIEDTYPE"
-  };
+    type: 'APIERROR'
+  }
+  ;
 };
 
 export default VirtualLeaguePage;

--- a/pages/virtual-leagues/[type].tsx
+++ b/pages/virtual-leagues/[type].tsx
@@ -1,30 +1,43 @@
 import { NextPage, NextPageContext } from "next";
 import VirtualLeaguePageContent from "../../components/virtual-leagues/VirtualLeaguePageContent";
-import {
-  getVerifiedEntries as getVirtualLeagues,
-  GetVerifiedEntriesResponse,
-} from "../../services/verified";
+import { getVerifiedEntries, GetVerifiedEntriesResponse, } from "../../services/verified";
 import { toVerifiedType, VerifiedType } from "../../services/VerifiedType";
 import { getVerifiedExtraInformation } from "../../utils/verifiedTypeHelper";
 
-interface PageProps {
+type LegalVerifiedType = {
   res: GetVerifiedEntriesResponse;
-  verifiedType: VerifiedType;
-}
+  verifiedType: VerifiedType
+  type: "LEGALVERIFIEDTYPE"
+};
 
-const VirtualLeaguePage: NextPage<PageProps> = ({ res, verifiedType }) => {
-  if (res.type === "SUCCESS") {
+type IllegalVerifiedType = {
+  illegalVerifiedType: string,
+  type: "ILLEGALVERIFIEDTYPE"
+};
 
-    const verifiedTypeInfo = getVerifiedExtraInformation(verifiedType);
+type VirtualLeaguePageProps = LegalVerifiedType | IllegalVerifiedType;
+
+const VirtualLeaguePage: NextPage<VirtualLeaguePageProps> = props => {
+  if (props.type === "LEGALVERIFIEDTYPE" && props.res.type == "SUCCESS") {
+
+    const verifiedTypeInfo = getVerifiedExtraInformation(props.verifiedType);
 
     return (
       <VirtualLeaguePageContent
         title={verifiedTypeInfo.title}
         description={verifiedTypeInfo.description}
-        verifiedEntries={res.data}
-        relUrl={verifiedType}
+        verifiedEntries={props.res.data}
+        relUrl={props.verifiedType}
       />
     );
+  }
+
+  if (props.type === "ILLEGALVERIFIEDTYPE") {
+    return (
+      <p className="pb-16 text-lg∆ md:text-xl text-fpl-purple text-center">
+        The virtual league {props.illegalVerifiedType} does not exist 🤷‍♂️
+      </p>
+    )
   }
 
   return (
@@ -35,11 +48,26 @@ const VirtualLeaguePage: NextPage<PageProps> = ({ res, verifiedType }) => {
 };
 
 VirtualLeaguePage.getInitialProps = async (ctx: NextPageContext) => {
-  const verifiedType = toVerifiedType(ctx.query.type as string);
-  var res = await getVirtualLeagues(verifiedType);
+  let verifiedType: VerifiedType = 'Unknown';
+
+  try {
+    verifiedType = toVerifiedType(ctx.query.type as string);
+  } catch {
+
+    if (ctx.res)
+      ctx.res.statusCode = 404;
+
+    return {
+      illegalVerifiedType: ctx.query.type as string,
+      type: 'ILLEGALVERIFIEDTYPE'
+    }
+  }
+
+  var res = await getVerifiedEntries(verifiedType);
   return {
     res: res,
     verifiedType: verifiedType,
+    type: "LEGALVERIFIEDTYPE"
   };
 };
 

--- a/pages/virtual-leagues/[type].tsx
+++ b/pages/virtual-leagues/[type].tsx
@@ -1,6 +1,6 @@
 import { NextPage, NextPageContext } from "next";
 import VirtualLeaguePageContent from "../../components/virtual-leagues/VirtualLeaguePageContent";
-import { getVerifiedEntries, VerifiedEntry, } from "../../services/verified";
+import { getVerifiedEntries, GetVerifiedEntriesError, VerifiedEntry } from "../../services/verified";
 import { toVerifiedType, VerifiedType } from "../../services/VerifiedType";
 import { getVerifiedExtraInformation } from "../../utils/verifiedTypeHelper";
 
@@ -15,11 +15,7 @@ interface IllegalVerifiedType {
   type: "ILLEGALVERIFIEDTYPE"
 };
 
-interface APIError {
-  type: "APIERROR"
-};
-
-type VirtualLeaguePageProps = LegalVerifiedType | IllegalVerifiedType | APIError;
+type VirtualLeaguePageProps = LegalVerifiedType | IllegalVerifiedType | GetVerifiedEntriesError;
 
 const VirtualLeaguePage: NextPage<VirtualLeaguePageProps> = props => {
   if (props.type === "LEGALVERIFIEDTYPE") {
@@ -74,9 +70,7 @@ VirtualLeaguePage.getInitialProps = async (ctx: NextPageContext) => {
       type: "LEGALVERIFIEDTYPE"
     }
   }
-  return {
-    type: 'APIERROR'
-  };
+  return res;
 };
 
 export default VirtualLeaguePage;

--- a/pages/virtual-leagues/[type].tsx
+++ b/pages/virtual-leagues/[type].tsx
@@ -4,13 +4,13 @@ import { getVerifiedEntries, GetVerifiedEntriesResponse, } from "../../services/
 import { toVerifiedType, VerifiedType } from "../../services/VerifiedType";
 import { getVerifiedExtraInformation } from "../../utils/verifiedTypeHelper";
 
-type LegalVerifiedType = {
+interface LegalVerifiedType  {
   res: GetVerifiedEntriesResponse;
   verifiedType: VerifiedType
   type: "LEGALVERIFIEDTYPE"
 };
 
-type IllegalVerifiedType = {
+interface IllegalVerifiedType {
   illegalVerifiedType: string,
   type: "ILLEGALVERIFIEDTYPE"
 };

--- a/pages/virtual-leagues/[type].tsx
+++ b/pages/virtual-leagues/[type].tsx
@@ -62,7 +62,7 @@ VirtualLeaguePage.getInitialProps = async (ctx: NextPageContext) => {
     }
   }
 
-  var res = await getVerifiedEntries(verifiedType);
+  const res = await getVerifiedEntries(verifiedType);
   if(res.type == "SUCCESS"){
     return {
       data: res.data,

--- a/pages/virtual-leagues/[type].tsx
+++ b/pages/virtual-leagues/[type].tsx
@@ -52,11 +52,10 @@ const VirtualLeaguePage: NextPage<VirtualLeaguePageProps> = props => {
 };
 
 VirtualLeaguePage.getInitialProps = async (ctx: NextPageContext) => {
-  let verifiedType: VerifiedType = 'Unknown';
 
-  try {
-    verifiedType = toVerifiedType(ctx.query.type as string);
-  } catch {
+  const verifiedType =  toVerifiedType(ctx.query.type as string);
+
+  if(verifiedType == null){
 
     if (ctx.res)
       ctx.res.statusCode = 404;
@@ -77,8 +76,7 @@ VirtualLeaguePage.getInitialProps = async (ctx: NextPageContext) => {
   }
   return {
     type: 'APIERROR'
-  }
-  ;
+  };
 };
 
 export default VirtualLeaguePage;

--- a/services/VerifiedType.ts
+++ b/services/VerifiedType.ts
@@ -27,7 +27,9 @@ export const toVerifiedType = (verifiedType: string): VerifiedType  => {
       return "TvFace";
     case 'athlete':
       return "Athlete";
-    default:
+    case 'unknown':
       return 'Unknown'
+    default:
+      throw 'Illegal verifiedType'
   };
 };

--- a/services/VerifiedType.ts
+++ b/services/VerifiedType.ts
@@ -9,7 +9,7 @@ export type VerifiedType = "Unknown" |
   "TvFace" |
   "Athlete";
 
-export const toVerifiedType = (verifiedType: string): VerifiedType  => {
+export const toVerifiedType = (verifiedType: string): VerifiedType | null  => {
   switch (verifiedType.toLowerCase()) {
     case 'footballerinpl':
       return "FootballerInPL";
@@ -30,6 +30,6 @@ export const toVerifiedType = (verifiedType: string): VerifiedType  => {
     case 'unknown':
       return 'Unknown'
     default:
-      throw 'Illegal verifiedType'
+      return null;
   };
 };

--- a/services/verified.ts
+++ b/services/verified.ts
@@ -23,7 +23,7 @@ export interface VerifiedPLEntry {
 }
 
 export interface VerifiedEntry {
-  entryId: number;  
+  entryId: number;
   teamName: string;
   realName: string;
   pointsThisGw: number;
@@ -43,7 +43,7 @@ interface GetVerifiedPLEntriesSuccess {
   data: VerifiedPLEntry[];
 }
 
-interface GetVerifiedEntriesError {
+export interface GetVerifiedEntriesError {
   type: "ERROR";
 }
 


### PR DESCRIPTION
Sets the statuscode to 404 if a user visits a virtual league that does not exist﻿.


Mark, this could also have been implemented via a redirect to the generic 404 handler in Next.js, but not sure how to do it in TypeScript.

