### PR TITLE
Incremental UI update of league-summary rendering

### DIFF
--- a/components/Chip.tsx
+++ b/components/Chip.tsx
@@ -1,4 +1,4 @@
-import { ChipType } from "../services/verified";
+import { ChipType } from "../services/fpl";
 
 export interface ChipProps {
   chipUsed: ChipType;

--- a/pages/leagues/[id].tsx
+++ b/pages/leagues/[id].tsx
@@ -152,19 +152,19 @@ const SummaryList = ({ leagueId }: SummaryListProps) => {
   return (
     <div className="league-transfers mx-auto divide-y-2 divide-grey-light">
       {gameweekSummary.data.map((value) => (
-        <div key={value.playerName} className="pt-4">
-          <div className="text-left align-top font-bold">
+        <div key={value.playerName} className="rounded-lg shadow bg-white mb-5">
+          <div className="align-top p-3 mb-3 bg-fpl-purple text-white rounded-t-lg shadow">
             <a
               href={`https://fantasy.premierleague.com/entry/${value.entry}/history`}
-              className="underline"
+              className="underline font-bold"
             >
               {value.playerName}
             </a>
-            {value.chip !== undefined && <span className="pl-4"><Chip chipUsed={value.chip.name} /></span>}
           </div>
-          <p className="pt-4 pb-3 text-left pl-3"><b>Captains: </b></p>
-          <p className="mb-4 text-left pl-4"><b></b>{value.captain} (C) - {value.viceCaptain} (VC) </p>
-          <p className="text-left pl-3"><b>Transfers: </b></p>
+          <span className="text-left"><b></b>{value.captain} (C) & {value.viceCaptain} (VC) </span>
+            {value.chip !== undefined && <div className="font-bold mb-4 text-sm mr-1"><Chip chipUsed={value.chip.name} />!</div>}
+
+
           <div className="text-left p-3">
             {value.transfers.length > 0 ? (
               value.transfers.map((item, i) => (

--- a/pages/leagues/[id].tsx
+++ b/pages/leagues/[id].tsx
@@ -175,7 +175,7 @@ const SummaryList = ({ leagueId }: SummaryListProps) => {
                   {/*<div className="italic text-xs text-gray-500">
                     {timeFormatted(item.time)}
                   </div>*/}
-                  <div className="rounded-md pl-1 mb-1 flex">
+                  <div className="rounded-md pl-1 mb-1 flex text-xs md:text-base">
                     <div className="w-2/5">
                       <svg width="24" height="19" viewBox="0 0 24 19" className="fill-current text-red-500 inline-flex mr-1">
                         <polygon fill-rule="evenodd" points="12.82 0 12.82 4.75 0 4.75 0 14.25 12.82 14.25 12.82 19 24 9.5" transform="rotate(-180 12 9.5)">

--- a/pages/leagues/[id].tsx
+++ b/pages/leagues/[id].tsx
@@ -153,7 +153,7 @@ const SummaryList = ({ leagueId }: SummaryListProps) => {
     <div className="league-transfers mx-auto divide-y-2 divide-grey-light">
       {gameweekSummary.data.map((value) => (
         <div key={value.playerName} className="rounded-lg shadow bg-white mb-5">
-          <div className="align-top p-3 mb-3 bg-fpl-purple text-white rounded-t-lg shadow">
+          <div className="align-top p-3 bg-fpl-purple text-white rounded-t-lg shadow">
             <a
               href={`https://fantasy.premierleague.com/entry/${value.entry}/history`}
               className="underline font-bold"
@@ -161,8 +161,9 @@ const SummaryList = ({ leagueId }: SummaryListProps) => {
               {value.playerName}
             </a>
           </div>
-          <span className="text-left"><b></b>{value.captain} (C) & {value.viceCaptain} (VC) </span>
-            {value.chip !== undefined && <div className="font-bold mb-4 text-sm mr-1"><Chip chipUsed={value.chip.name} />!</div>}
+          {value.chip !== undefined && <div className="font-bold text-sm bg-fpl-green text-fpl-purple"><Chip chipUsed={value.chip.name} />!</div>}
+
+          <div className="p-3"><b></b>{value.captain} (C) & {value.viceCaptain} (VC) </div>
 
 
           <div className="text-left p-3">

--- a/pages/leagues/[id].tsx
+++ b/pages/leagues/[id].tsx
@@ -129,14 +129,11 @@ const SummaryList = ({ leagueId }: SummaryListProps) => {
 
   useEffect(() => {
     fetchSummary();
-  },[])
+  }, [])
 
   function fetchSummary() {
     getGameweekSummary(leagueId, summaries => {
-      setGameweekSummary({
-        type: "DATA",
-        data: summaries
-      });
+      setGameweekSummary(summaries);
     });
   }
 

--- a/pages/leagues/[id].tsx
+++ b/pages/leagues/[id].tsx
@@ -104,7 +104,7 @@ const Content = ({ leagueId }: ContentProps) => {
           </tbody>
           <tfoot className={!showFullTable ? "sm:visible md:hidden lg:hidden xl:hidden 2xl:hidden" : "hidden"}>
             <tr >
-              <td onClick={showCompleteTable} colSpan={3} className="font-extrabold shadow hover:shadow-xl transition duration-500 text-center text-sm bg-fpl-purple text-white hover:bg-fpl-green hover:text-fpl-purple cursor-pointer">
+              <td onClick={showCompleteTable} colSpan={3} className="font-extrabold shadow hover:shadow-xl transition duration-500 text-center text-sm p-3 bg-white text-gray-500 hover:bg-gray-100 hover:text-fpl-purple cursor-pointer">
                 +
             </td>
             </tr>

--- a/services/fpl.ts
+++ b/services/fpl.ts
@@ -1,0 +1,72 @@
+export interface LeagueRes {
+  league: League;
+  standings: Standings;
+}
+
+export interface League {
+  id: number;
+  name: string;
+}
+
+export interface Entry {
+  entry: number;
+  player_name: string;
+  rank: number;
+  total: number;
+}
+
+export interface Standings {
+  results: Entry[];
+}
+
+export interface Transfer {
+  element_in: number;
+  element_in_cost: number;
+  element_out: number;
+  element_out_cost: number;
+  event: number;
+  time: Date;
+}
+
+export interface Bootstrap {
+  elements: Player[];
+  events: Event[];
+}
+
+export interface Player {
+  id: number;
+  web_name: string;
+  code: string;
+}
+
+export interface Event {
+  id: number;
+  is_current: boolean;
+}
+
+export interface EntryHistory {
+  chips: Chip[];
+}
+
+export type ChipType = "3xc" | "wildcard" | "freehit" | "bboost";
+
+export interface Chip {
+  name: ChipType;
+  time: Date;
+  event: number;
+}
+
+export interface Pick {
+  element: number;
+  is_captain: boolean;
+  is_vice_captain: boolean;
+}
+
+export interface EntryHistory {
+  chips: Chip[];
+}
+
+export interface PicksRes {
+  picks: Pick[];
+}
+

--- a/services/leagues.ts
+++ b/services/leagues.ts
@@ -122,7 +122,7 @@ export type CurrentGameweekSummaryState =
 
 export async function getGameweekSummary(
   id: number,
-  listUpdate : (summaries:CurrentGameweekSummary[]) => void
+  listUpdate?: (summaries: CurrentGameweekSummaryData) => void
 ): Promise<CurrentGameweekSummaryState> {
   const leagueRes = await http<LeagueRes>(`/api/fpl/leagues-classic/${id}/standings/`);
   const entries = leagueRes.standings.results;
@@ -184,7 +184,12 @@ export async function getGameweekSummary(
         captain: captainPlayer.web_name,
         viceCaptain: viceCaptainPlayer.web_name
       });
-      listUpdate(currentGameweekSummary);
+
+      if (listUpdate)
+        listUpdate({
+          type: "DATA",
+          data: currentGameweekSummary,
+        });
     }
 
     return {

--- a/services/leagues.ts
+++ b/services/leagues.ts
@@ -116,14 +116,16 @@ interface CurrentGameweekSummaryData {
 }
 
 export type CurrentGameweekSummaryState =
-  | Init
   | Loading
   | Error
   | CurrentGameweekSummaryData;
 
 export async function getGameweekSummary(
-  entries: Entry[]
+  id: number,
+  listUpdate : (summaries:CurrentGameweekSummary[]) => void
 ): Promise<CurrentGameweekSummaryState> {
+  const leagueRes = await http<LeagueRes>(`/api/fpl/leagues-classic/${id}/standings/`);
+  const entries = leagueRes.standings.results;
   try {
     const bootstrap = await http<Bootstrap>(`/api/fpl/bootstrap-static/`);
     const currentGw = bootstrap.events.filter((e) => e.is_current)[0];
@@ -182,6 +184,7 @@ export async function getGameweekSummary(
         captain: captainPlayer.web_name,
         viceCaptain: viceCaptainPlayer.web_name
       });
+      listUpdate(currentGameweekSummary);
     }
 
     return {

--- a/services/leagues.ts
+++ b/services/leagues.ts
@@ -1,5 +1,5 @@
 import useSWR from "swr";
-import { ChipType } from "./verified";
+import { Bootstrap, Chip, Entry, EntryHistory, LeagueRes, PicksRes, Player, Standings, Transfer, Event } from "./fpl";
 
 interface Init {
   type: "INIT";
@@ -12,83 +12,12 @@ interface Error {
   type: "ERROR";
 }
 
-interface League {
-  id: number;
-  name: string;
-}
-
-export interface Entry {
-  entry: number;
-  player_name: string;
-  rank: number;
-  total: number;
-}
-
-interface Standings {
-  results: Entry[];
-}
-
-export interface LeagueRes {
-  league: League;
-  standings: Standings;
-}
-
-interface Transfer {
-  element_in: number;
-  element_in_cost: number;
-  element_out: number;
-  element_out_cost: number;
-  event: number;
-  time: Date;
-}
-
-interface Bootstrap {
-  elements: Player[];
-  events: Event[];
-}
-
-interface Player {
-  id: number;
-  web_name: string;
-  code: string;
-}
-
-interface Event {
-  id: number;
-  is_current: boolean;
-}
-
 export interface EntryTransfer {
   playerIn: Player;
   playerInCost: string;
   playerOut: Player;
   playerOutCost: string;
   time: Date;
-}
-
-interface EntryHistory {
-  chips: Chip[];
-}
-
-interface Chip {
-  name: ChipType;
-  time: Date;
-  event: number;
-
-}
-
-interface EntryHistory {
-  chips: Chip[];
-}
-
-interface PicksRes {
-  picks: Pick[];
-}
-
-interface Pick {
-  element: number;
-  is_captain: boolean;
-  is_vice_captain: boolean;
 }
 
 export async function http<T>(request: RequestInfo): Promise<T> {
@@ -101,6 +30,7 @@ export async function http<T>(request: RequestInfo): Promise<T> {
     status: response.status,
   });
 }
+
 export interface CurrentGameweekSummary {
   playerName: string;
   entry: number;
@@ -150,7 +80,6 @@ export async function getGameweekSummary(
           type: "ERROR"
         };
       }
-
     }
 
     return {

--- a/services/leagues.ts
+++ b/services/leagues.ts
@@ -63,9 +63,7 @@ export async function getGameweekSummary(
     const currentGameweekSummary: CurrentGameweekSummary[] = [];
     for await (const entry of entries) {
       try {
-        const summary = await summaryForEntry(entry, currentGw, bootstrap);
-
-        currentGameweekSummary.push(summary);
+        currentGameweekSummary.push(await summaryForEntry(entry, currentGw, bootstrap));
         if (listUpdate)
           listUpdate({
             type: "DATA",

--- a/services/verified.ts
+++ b/services/verified.ts
@@ -1,4 +1,5 @@
 import { FPLBOT_API_BASEURL } from "../utils/envconfig";
+import { ChipType } from "./fpl";
 
 export interface VerifiedPLEntry {
   entryId: number;
@@ -38,8 +39,6 @@ export interface VerifiedEntry {
   movement: number;
   gameweek: number;
 }
-
-export type ChipType = "3xc" | "wildcard" | "freehit" | "bboost";
 
 interface GetVerifiedPLEntriesSuccess {
   type: "SUCCESS";


### PR DESCRIPTION
- Removes btn to fetch. Now renders league summary on mount.
- Loads summary UI entries as they are fetched one-by-one instead of waiting for all entries to be fetched